### PR TITLE
fix: contact page e2e test

### DIFF
--- a/packages/frontend/e2e/cypress/e2e/contact.cy.js
+++ b/packages/frontend/e2e/cypress/e2e/contact.cy.js
@@ -12,17 +12,18 @@ describe("Contact Page", () => {
     cy.get("h2").contains("Zostaw wiadomość")
   })
 
-  it.skip(`sends the form after clicking submit button`, () => {
+  it(`sends the form after clicking submit button`, () => {
     cy.intercept("POST", "https://formspree.io/f/*", { ok: true }).as(
       "formSubmit"
     )
 
     cy.get('input[name="Imię"]').type("test")
     cy.get('input[name="Mail"]').type("test@test")
-    cy.get("select").select("dom-tymczasowy")
-    cy.get("textarea").type(
+    cy.get('select[name="Temat"]').select("dom-tymczasowy")
+    cy.get('textarea[name="Wiadomość"]').type(
       "Hi, I'm sending test message, it has to be 30 characters long."
     )
+    cy.get('input[type="checkbox"]').check()
 
     cy.get("form").submit()
 

--- a/packages/frontend/e2e/cypress/e2e/contact.cy.js
+++ b/packages/frontend/e2e/cypress/e2e/contact.cy.js
@@ -13,9 +13,10 @@ describe("Contact Page", () => {
   })
 
   it(`sends the form after clicking submit button`, () => {
-    cy.intercept("POST", "https://formspree.io/f/*", { ok: true }).as(
-      "formSubmit"
-    )
+    cy.intercept("POST", "https://formspree.io/f/*", {
+      next: "/thanks?language=pl",
+      ok: true,
+    }).as("formSubmit")
 
     cy.get('input[name="Imię"]').type("test")
     cy.get('input[name="Mail"]').type("test@test")


### PR DESCRIPTION
## Description 📝

Contact page E2E test (form submit) isn't skipped anymore. I've updated the form field names and added the checkbox field.

## Related Issues 🔗

<!-- List any related issues or pull requests -->

JIRA issue: [FSU-310](https://klau.atlassian.net/browse/FSU-310)

## Preview Links 🔍

<!-- Below are the links to see how the changes look:
- [Storybook](link_to_storybook_preview_if_needed)
- [Home](link_to_webpage_preview_if_needed)
-->
