### PR TITLE
fix(single-animal): text alignement in the details

### DIFF
--- a/packages/frontend/app/templates/Animal/components/Details/Details.styled.js
+++ b/packages/frontend/app/templates/Animal/components/Details/Details.styled.js
@@ -5,6 +5,8 @@ export const Feature = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 20px;
+  text-align: end;
 `
 
 export const Tabs = styled.div`


### PR DESCRIPTION
## Description 📝

This PR fixes the alignment in the details section - Single Animal page.
The issue happens only with longer text on the right side, on smaller viewports.

https://www.sterczaceuszy.pl/do-adopcji/figa

## Related Issues 🔗

<!-- List any related issues or pull requests -->

JIRA issue: [FSU-361](https://klau.atlassian.net/browse/FSU-361)

## Preview Links 🔍

- [Single animal page](https://sterczaceuszy-git-fsu-361-single-animal-p-a43068-sterczace-uszy.vercel.app/do-adopcji/alex)

