### PR TITLE
fix: change checkbox layout to change checkbox state on label click

### DIFF
--- a/packages/design-system/components/checkbox/Checkbox.jsx
+++ b/packages/design-system/components/checkbox/Checkbox.jsx
@@ -19,31 +19,27 @@ const Checkbox = ({
     setIsChecked((prev) => !prev)
   }
 
-  const checkHandler = () => {
-    setIsChecked(!isChecked)
-  }
-
   return (
-    <Styled.Container onClick={!disabled && handleCheckboxChange}>
-      <Styled.Checkbox
-        checked={isChecked}
-        onChange={checkHandler}
-        error={error}
-        required={required}
-        disabled={disabled}
-        type="checkbox"
-        id={id}
-        className={className}
-      />
-      {isChecked && (
-        <Styled.CheckboxIcon
-          name="check"
-          size="small"
-          color={theme.colors.neutrals[100]}
-          data-testid="checkbox-icon"
-        />
-      )}
+    <Styled.Container>
       <Styled.Label htmlFor={id}>
+        <Styled.Checkbox
+          checked={isChecked}
+          onChange={!disabled && handleCheckboxChange}
+          error={error}
+          required={required}
+          disabled={disabled}
+          type="checkbox"
+          id={id}
+          className={className}
+        />
+        {isChecked && (
+          <Styled.CheckboxIcon
+            name="check"
+            size="small"
+            color={theme.colors.neutrals[100]}
+            data-testid="checkbox-icon"
+          />
+        )}
         <Typography
           variant="bodySmall"
           color={disabled ? theme.colors.gray[400] : theme.colors.gray[600]}

--- a/packages/design-system/components/checkbox/Checkbox.styled.js
+++ b/packages/design-system/components/checkbox/Checkbox.styled.js
@@ -3,15 +3,12 @@ import Icon from "design-system/components/icon"
 
 export const Label = styled.label`
   display: flex;
-  flex-direction: column;
-  gap: 7px;
+  gap: 19px;
   color: ${({ theme }) => theme.colors.gray[600]};
 `
 
 export const Container = styled.div`
   position: relative;
-  display: flex;
-  gap: 19px;
 `
 
 export const Checkbox = styled.input`


### PR DESCRIPTION
## Description 📝

I changed the checkbox layout - wrapped checkbox in label and removed one `onClick` handler to be able to change checkbox state when clicking on the label itself.

## Related Issues 🔗

JIRA issue: [FSU-360](https://klau.atlassian.net/browse/FSU-360)

## Preview Links 🔍

![chrome-capture-2023-9-4](https://github.com/non-profit-dev/sterczace-uszy/assets/7822177/766d113b-580f-4acb-9322-9992d12294d4)
