### PR TITLE
feat: remove the second phone number

### DIFF
--- a/packages/design-system/blocks/footer/Footer.jsx
+++ b/packages/design-system/blocks/footer/Footer.jsx
@@ -62,15 +62,6 @@ const Footer = () => {
                     href={globalData.contact.phoneFirst.link}
                   />
                 </ListItem>
-                <ListItem iconName="phone" size="medium" variant="gray">
-                  <Button
-                    variant="text"
-                    text={`${globalData.contact.phoneSecond.text} - sms`}
-                    size="xsmall"
-                    color="black"
-                    href={globalData.contact.phoneSecond.link}
-                  />
-                </ListItem>
                 <ListItem iconName="location" size="medium" variant="gray">
                   <Button
                     variant="text"

--- a/packages/frontend/app/templates/Contact/components/ContactInfo/ContactInfo.jsx
+++ b/packages/frontend/app/templates/Contact/components/ContactInfo/ContactInfo.jsx
@@ -14,11 +14,6 @@ const listData = [
     link: globalData.contact.phoneFirst.link,
   },
   {
-    iconName: "phone",
-    text: `${globalData.contact.phoneSecond.text} - sms`,
-    link: globalData.contact.phoneSecond.link,
-  },
-  {
     iconName: "mail",
     text: globalData.contact.mail.text,
     link: globalData.contact.mail.link,

--- a/packages/shared/data/index.js
+++ b/packages/shared/data/index.js
@@ -22,10 +22,6 @@ const globalData = {
       text: "500-433-539",
       link: "tel:+48500433539",
     },
-    phoneSecond: {
-      text: "661-753-896",
-      link: "tel:+48661753896",
-    },
     location: {
       text: "Luboń",
       link: "https://www.google.pl/maps/place/Lubo%C5%84/",


### PR DESCRIPTION
## Description 📝

According to the latest client's request - I've removed the second phone number from the Contact information.

There should be always one number visible.