### PR TITLE
test: mock current date to render animal's badge

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -20,5 +20,8 @@
   },
   "scripts": {
     "test": "jest --verbose"
+  },
+  "dependencies": {
+    "jest-date-mock": "^1.0.8"
   }
 }

--- a/packages/design-system/patterns/animalCard/__tests__/AnimalCard.test.jsx
+++ b/packages/design-system/patterns/animalCard/__tests__/AnimalCard.test.jsx
@@ -1,3 +1,4 @@
+import { advanceTo, clear } from "jest-date-mock"
 import { render, screen } from "design-system/test-utils"
 
 import AnimalCard from "design-system/patterns/animalCard"
@@ -25,6 +26,13 @@ const femaleAnimal = {
 const femaleAnimalBadge = "Młoda suczka"
 
 describe(`AnimalCard`, () => {
+  beforeAll(() => {
+    advanceTo(new Date(2023, 1, 7))
+  })
+
+  afterAll(() => {
+    clear()
+  })
   it(`renders animal's information`, () => {
     render(<AnimalCard {...animal} />)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9082,6 +9082,7 @@ __metadata:
     babel-jest: ^29.0.3
     babel-loader: ^8.2.5
     jest: ^29.0.3
+    jest-date-mock: ^1.0.8
     jest-environment-jsdom: ^29.0.3
     prop-types: ^15.8.1
   languageName: unknown
@@ -13668,6 +13669,13 @@ __metadata:
     ts-node:
       optional: true
   checksum: 3bd104a3ac2dd9d34986238142437606354169766dcf88359a7a12ac106d0dc17dcc6b627e4f20db97a58bac5b0502b5436c9cc4722b3629b2a114bba6da9128
+  languageName: node
+  linkType: hard
+
+"jest-date-mock@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "jest-date-mock@npm:1.0.8"
+  checksum: 7b012870440b0df742d0b651435b91625dbbf02d916633a0c70c7deb5d5087f9aadc59847602312368826325909e70e95cd412896a0c9ee1d5ac382000bf5ef9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description 📝

By controlling the current date in tests, we can ensure consistent and reliable test outcomes, regardless of when the tests are run.

Now:
- We use `advanceTo` from jest-date-mock to set the current date to a fixed value (February 7, 2023) before running the tests.
- After all tests are executed, we use `clear` to restore the original behavior of Date, ensuring it doesn't affect other tests or code.

## Resources 📚
https://www.npmjs.com/package/jest-date-mock